### PR TITLE
Fix five critical bugs in barcode encoding

### DIFF
--- a/BarcodeKit/BaseEANUPC.cpp
+++ b/BarcodeKit/BaseEANUPC.cpp
@@ -70,10 +70,10 @@ void BaseEANUPC::encodeCheckCharacter ( const string *data )
 {	
 	int multiples[12] = {1,3,1,3,1,3,1,3,1,3,1,3};
 	int accumulator = 0;
-	int count = NULL;
+	int count = 0;
 	int dsl = data->length();
-	
-	switch (dsl) 
+
+	switch (dsl)
 	{
 		case 12:
 			count = 0;
@@ -85,6 +85,7 @@ void BaseEANUPC::encodeCheckCharacter ( const string *data )
 			count = 5;
 			break;
 		default:
+			count = 0;
 			break;
 	}
 	

--- a/BarcodeKit/Code128.cpp
+++ b/BarcodeKit/Code128.cpp
@@ -117,7 +117,7 @@ bool Code128::verifyContent ( const string *content )
 	for ( int nn = 0; nn < content->length( ); nn++ ) 
 	{
 		char testChar = content->at( nn );
-		if ( ( int )testChar < 0 && ( int )testChar > 127 ) 
+		if ( ( int )testChar < 0 || ( int )testChar > 127 ) 
 		{
 			cerr << "You are trying to encode " << content->at( nn ) << " which is not supported by this barcode type." << endl;
 			return false;

--- a/BarcodeKit/Interleaved2of5.cpp
+++ b/BarcodeKit/Interleaved2of5.cpp
@@ -77,11 +77,11 @@ void Interleaved2of5::encodeSymbol ( const string *data )
 	string returnedData1, returnedData2;
 	string ASCII = kASCII;
 	
-	for ( int ii = 0; ii < data->length( ); ii++ ) 
+	for ( int ii = 0; ii + 1 < (int)data->length( ); ii += 2 )
 	{
 		char char1 = data->at( ii );
 		char char2 = data->at( ii + 1 );
-		
+
 		string suffix1, suffix2;
 		stringstream output1, output2;
 		output1 << ( int )char1;
@@ -94,23 +94,22 @@ void Interleaved2of5::encodeSymbol ( const string *data )
 		string search1 = ASCII.append( suffix1 );
 		ASCII = kASCII;
 		string search2 = ASCII.append( suffix2 );
-		
+
 		node = parsed_xml.first_node( )->first_node( )->next_sibling( "data_encoding" )->first_node( search1.c_str( ) )->first_node( "Interleaved" );
 		returnedData1 = node->value( );
 		node = parsed_xml.first_node( )->first_node( )->next_sibling( "data_encoding" )->first_node( search2.c_str( ) )->first_node( "Interleaved" );
 		returnedData2 = node->value( );
-		
+
 		string combinedData;
-		for ( int xx = 0; xx < returnedData1.length( ); xx++ ) 
+		for ( int xx = 0; xx < returnedData1.length( ); xx++ )
 		{
 			combinedData.append( 1, returnedData1.at( xx ) );
 			combinedData.append( 1, returnedData2.at( xx ) );
 		}
-		
+
 		vector< int > *pattern = stringToVector( combinedData );
 		Symbol *iSymbol = createSymbol( 0, 0, 1, 0, pattern );
 		BaseBarcode::addEncodedSymbol( iSymbol );
-		ii++;
 	}
 }
 
@@ -150,38 +149,37 @@ void Interleaved2of5::encodeQuietZones ( )
 void Interleaved2of5::encodeCheckCharacter ( const string *data )
 {
 	int accum1 = 0, accum2 = 0;
-	for ( int cc = data->length( ) - 1; cc > 0; cc-- ) 
+	// Sum digits at odd positions from the right (1st, 3rd, 5th, ...)
+	for ( int cc = (int)data->length( ) - 1; cc >= 0; cc -= 2 )
 	{
 		char eachOdd = data->at( cc );
-		accum1 = accum1 + atoi( &eachOdd ) ;
-		cc--;
+		accum1 = accum1 + atoi( &eachOdd );
 	}
-	for ( int cc = data->length( ) - 1; cc > 0; cc--)
+	// Sum digits at even positions from the right (2nd, 4th, 6th, ...)
+	for ( int cc = (int)data->length( ) - 2; cc >= 0; cc -= 2 )
 	{
-		cc--;
 		char eachEven = data->at( cc );
 		accum2 = accum2 + atoi( &eachEven );
 	}
-	
-	accum1 = ( accum1 * 3 ) + accum2;
-	int checkchar = (char)kModulus -  ( accum1 % kModulus );
-	
+
+	int total = ( accum1 * 3 ) + accum2;
+	int checkchar = ( kModulus - ( total % kModulus ) ) % kModulus;
+
 	string suffix;
 	stringstream output;
 	output << checkchar;
 	suffix = output.str( );
 	output.flush( );
-	
+
 	string *newString = new string ( *data );
-	
+
 	newString->append( suffix );
-	
-	if ( newString->length( ) % 2 == 1 ) 
+
+	if ( newString->length( ) % 2 == 1 )
 	{
 		newString->insert( newString->begin( ), '0' );
 	}
 	completedDataString = *newString;
-	cout << completedDataString << endl;
 	encodeSymbol( newString );
 }
 

--- a/BarcodeKit/Symbol.cpp
+++ b/BarcodeKit/Symbol.cpp
@@ -139,7 +139,7 @@ void Symbol::arrayIntoVector( int source[ ], int sourceLength, vector<int> &dest
 		for ( iter = 0; iter < sourceLength; iter++ )	//loop through the source assigning to the destination
 		{
 			int holdingVar = source[ iter ];
-			destination.assign( iter, holdingVar );
+			destination[ iter ] = holdingVar;
 		}
 		if ( destination.capacity( ) == 0 )
 		{

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,317 @@
+# BarcodeKit — Code Review
+
+## Overview
+
+BarcodeKit is a C++ library for generating 1D barcodes. It supports eight formats across two families:
+
+- **EAN/UPC family**: EAN-13, EAN-8, UPC-A, UPC-E
+- **Linear family**: Code 39, Code 128, Codabar, Interleaved 2of5
+
+The overall architecture is well-conceived for a thesis project. The library uses the **Template Method pattern** effectively — `BaseBarcode` defines the encoding pipeline (verify → encode symbols → encode check character → encode start/stop → encode quiet zones) and subclasses fill in each step. The **XML-driven encoding data** (bar/space patterns stored in `.xml` files and loaded at runtime via RapidXML) is a clean design that separates encoding configuration from logic. The `Symbol` abstraction correctly decouples the data model from any rendering concern.
+
+That said, there are several correctness bugs, memory management problems, and architectural issues described below.
+
+---
+
+## 1. Critical Bugs
+
+These issues will cause incorrect barcode output or program crashes.
+
+### 1.1 `Symbol::arrayIntoVector()` — wrong `vector` overload called
+
+**File:** `BarcodeKit/Symbol.cpp` (~line 142)
+
+```cpp
+for ( iter = 0; iter < sourceLength; iter++ )
+{
+    int holdingVar = source[ iter ];
+    destination.assign( iter, holdingVar );  // Wrong overload
+}
+```
+
+`vector::assign(size_t count, const T& value)` replaces the **entire contents** of the vector with `count` copies of `value`. On every iteration this overwrites all previous elements. After the loop, the vector contains `sourceLength` copies of the **last** element only, discarding all prior values.
+
+The intended call is:
+
+```cpp
+destination[iter] = holdingVar;
+```
+
+This bug means every encoded symbol has corrupted bar/space data.
+
+---
+
+### 1.2 `Code128::verifyContent()` — impossible condition lets invalid input through
+
+**File:** `BarcodeKit/Code128.cpp` (~line 120)
+
+```cpp
+if ( ( int )testChar < 0 && ( int )testChar > 127 )
+```
+
+A value cannot simultaneously be less than 0 **and** greater than 127. This condition is always `false`, so the function always returns `true` regardless of input. The operator should be `||`:
+
+```cpp
+if ( ( int )testChar < 0 || ( int )testChar > 127 )
+```
+
+---
+
+### 1.3 `Interleaved2of5::encodeSymbol()` — out-of-bounds access on final iteration
+
+**File:** `BarcodeKit/Interleaved2of5.cpp` (~line 78)
+
+```cpp
+for ( int ii = 0; ii < data->length( ); ii++ )
+{
+    char char1 = data->at( ii );
+    char char2 = data->at( ii + 1 );  // Unsafe when ii == length - 1
+    ...
+    ii++;  // Manual increment (doubled with for-loop increment)
+}
+```
+
+When `ii` reaches the second-to-last index, `ii + 1` is valid. But the termination check `ii < data->length()` does not prevent `ii` from equalling `length - 1` on an iteration where `data->at(ii + 1)` would be out of bounds. The double increment (manual `ii++` plus the for-loop's `ii++`) also causes every other pair to be skipped if the length is odd, though the code does pad to an even length earlier.
+
+The loop should iterate with step 2 and check `ii + 1 < data->length()`:
+
+```cpp
+for ( int ii = 0; ii + 1 < (int)data->length( ); ii += 2 )
+```
+
+---
+
+### 1.4 `BaseEANUPC::encodeCheckCharacter()` — uninitialized `count`
+
+**File:** `BarcodeKit/BaseEANUPC.cpp` (~line 73)
+
+```cpp
+int count = NULL;  // NULL is a pointer constant, not 0
+...
+switch (dsl)
+{
+    case 12: count = 0; break;
+    case 11: count = 1; break;
+    case 7:  count = 5; break;
+    default: break;    // count not set
+}
+
+for ( int ii = 0; ii < dsl; ii++, count++ )
+{
+    accumulator += ( atoi(&aChar) * multiples[count] );  // UB if count uninitialised
+}
+```
+
+Two problems:
+
+1. `int count = NULL` assigns a pointer value to an integer. While most compilers allow this (NULL is typically `0`), it is semantically wrong. Use `int count = 0`.
+2. If `data->length()` is anything other than 12, 11, or 7, the `switch` hits `default` and `count` is never assigned. The subsequent for-loop then reads `multiples[count]` with an indeterminate index — undefined behaviour.
+
+---
+
+### 1.5 `Interleaved2of5::encodeCheckCharacter()` — double-decrement skips digits
+
+**File:** `BarcodeKit/Interleaved2of5.cpp` (~lines 150–186)
+
+```cpp
+for ( int cc = data->length( ) - 1; cc > 0; cc-- )
+{
+    char eachOdd = data->at( cc );
+    accum1 = accum1 + atoi( &eachOdd );
+    cc--;  // cc is also decremented by the for-loop head
+}
+```
+
+`cc` is decremented twice per iteration (once by the for-loop, once explicitly). This causes every other digit to be skipped and can produce a negative index, reading out-of-bounds. The same pattern appears in the second loop. The checksum result will be wrong.
+
+---
+
+## 2. Memory Management
+
+The codebase uses raw `new`/`delete` throughout with no RAII, leading to several leaks and a potential double-free.
+
+### 2.1 `BaseBarcode::getXMLToParse()` — `ft` is never deleted
+
+**File:** `BarcodeKit/BaseBarcode.cpp` (~line 147)
+
+```cpp
+char *ft = new char[ fileTitle->length( ) + 1 ];
+strcpy( ft, fileTitle->c_str( ) );
+// ... ft used, then function returns without delete[] ft
+```
+
+`ft` is allocated but never freed, leaking memory on every barcode construction.
+
+---
+
+### 2.2 `BaseBarcode::returnDOMValues()` — heap-allocated vector is leaked
+
+**File:** `BarcodeKit/BaseBarcode.cpp` (~line 177)
+
+```cpp
+vector<string> *returnValues = new vector<string>;
+// ... populate ...
+return *returnValues;  // Returns a copy; original heap allocation is never deleted
+```
+
+The vector is allocated on the heap, then dereferenced to return by value. The caller receives a copy; the heap allocation is never freed. Declaring `returnValues` as a local `vector<string>` and returning it directly would fix this.
+
+---
+
+### 2.3 `Symbol::getEncodedData()` — returns an owning raw pointer
+
+**File:** `BarcodeKit/Symbol.cpp` (~line 72)
+
+```cpp
+vector<int>* Symbol::getEncodedData( )
+{
+    vector<int> *tempVector = new vector<int>;
+    tempVector->insert( ... );
+    return tempVector;
+}
+```
+
+Every call allocates a new `vector<int>` on the heap. The caller is responsible for deleting it, but this ownership contract is implicit and undocumented. The method could return by value or `const` reference to the internal member instead.
+
+---
+
+### 2.4 `Code128` destructor — deletes null pointer
+
+**File:** `BarcodeKit/Code128.cpp` (~lines 83–87)
+
+```cpp
+Code128::~Code128( )
+{
+    checkCharList = NULL;
+    delete checkCharList;  // Deletes null — harmless but wrong order
+}
+```
+
+Setting a pointer to `NULL` before deleting it frees nothing. The `delete` should come **before** the assignment, or `checkCharList` should be wrapped in a `std::unique_ptr` so it is freed automatically.
+
+---
+
+### 2.5 `Code39.cpp` — same `Symbol*` added to deque twice
+
+**File:** `BarcodeKit/Code39.cpp` (~lines 134–135)
+
+```cpp
+Symbol *startstopSymbol = createSymbol( 4, 1, 1, 0, pattern );
+BaseBarcode::addEncodedSymbol( startstopSymbol, 0 );
+BaseBarcode::addEncodedSymbol( startstopSymbol, BaseBarcode::encodedSymbols.size( ) );
+```
+
+The same pointer is stored at two positions in the deque. If the deque's cleanup ever deletes stored symbols, this will cause a double-free (undefined behaviour).
+
+---
+
+## 3. Architecture & Design
+
+### 3.1 `encodeCheckCharacter()` calls `encodeSymbol()` — mixed responsibility
+
+In `BaseEANUPC` and `Interleaved2of5`, the check character method internally calls `encodeSymbol()`. The clean separation intended by the template method is broken: the pipeline step for computing the check character also triggers the symbol-encoding step. This makes the execution order hard to follow, prevents testing either step in isolation, and risks double-encoding if the calling order in the constructor is changed.
+
+Each step should have a single responsibility. `encodeCheckCharacter()` should only compute and append the check digit symbol; `encodeSymbol()` should only encode the data characters.
+
+---
+
+### 3.2 XML parsing duplicated across every constructor
+
+Every concrete barcode class manually:
+1. Allocates a `rapidxml::xml_document`
+2. Calls `getXMLToParse()` to load the file
+3. Calls `parsed_xml.parse<0>(...)`
+4. Navigates the DOM hierarchy by hand
+
+This identical boilerplate appears in Code39, Code128, Codabar, EAN-13, EAN-8, UPC-A, UPC-E, and Interleaved2of5. Factoring this into a protected helper in `BaseBarcode` (or a dedicated `EncodingTable` class) would remove the duplication and make each subclass constructor much shorter.
+
+---
+
+### 3.3 `symbolType` uses magic integers
+
+`Symbol` objects are constructed with integer literals like `createSymbol(0, ...)` or `createSymbol(4, ...)`. The meaning (0 = Data, 1 = CheckChar, 2 = QuietZone, 3 = GuardPattern, 4 = StartStop, 5 = NonData) is not documented anywhere in the source. An `enum class SymbolType` would make every call site self-documenting.
+
+---
+
+### 3.4 Debug output left in production code
+
+Several `cout` and `cerr` calls are clearly diagnostic and should be removed before shipping:
+
+| File | Approx. line | Output |
+|------|-------------|--------|
+| `BaseEANUPC.cpp` | ~50 | `"Passed content check"` |
+| `BaseEANUPC.cpp` | ~111 | (intermediate accumulator value) |
+| `UPCE.cpp` | ~70 | `"failed on leading zero"` |
+| `Interleaved2of5.cpp` | ~184 | `completedDataString` |
+
+---
+
+### 3.5 Inconsistent error handling
+
+The codebase uses at least three different error-reporting strategies:
+
+- Return `false` (e.g., `verifyContent()`)
+- Write to `cerr` (e.g., Code128 validation)
+- Throw a `std::string` (e.g., some length checks)
+
+A project this size should pick one approach and apply it consistently. Throwing typed exceptions (e.g., `std::invalid_argument`) or returning a `Result`/`Error` type would be preferable to throwing raw strings.
+
+---
+
+### 3.6 Unimplemented stubs
+
+Three items exist in the codebase but have no implementation:
+
+- **`Code16k`** — header and `.cpp` file exist but contain no logic.
+- **`IHumanReadableText`** — interface declared but empty.
+- **`Codabar::encodeCheckCharacter()`** — explicitly stubbed out with a comment.
+
+These should either be implemented or removed. Stub files create the impression of completeness and can confuse readers.
+
+---
+
+## 4. Code Quality & Style
+
+### 4.1 Typos in public API names
+
+| Current name | Correct name | Location |
+|---|---|---|
+| `getForcePostion()` | `getForcePosition()` | `Symbol.h`, `Symbol.cpp` |
+| `checkcharModulus` | `checkCharModulus` | `BaseBarcode.h/cpp` and several subclasses |
+
+---
+
+### 4.2 Unnecessary scope resolution inside member functions
+
+Throughout `Symbol.cpp`:
+
+```cpp
+int Symbol::getLeadingElement( )
+{
+    return Symbol::leadingElement;  // The Symbol:: prefix is redundant here
+}
+```
+
+Inside a member function the class scope is implicit. `Symbol::` is only needed for out-of-class definitions (which these are, but the qualifier goes on the function name, not the member access).
+
+---
+
+### 4.3 `using namespace` in implementation files
+
+All `.cpp` files open with `using namespace std;` and `using namespace rapidxml;`. This is acceptable in implementation files but should never appear in headers, where it forces the namespace on every file that includes the header. `IGuardPatterns.h` and `BaseBarcode.h` should use explicit `std::` prefixes.
+
+---
+
+### 4.4 `#pragma mark` is Objective-C–specific
+
+Several `.cpp` files use `#pragma mark` to delimit sections. This pragma is an Xcode/Clang extension for Objective-C. Standard C++ uses `// MARK:` comments or section headings. While harmless, it signals that the code was not written to be portable.
+
+---
+
+## 5. What Works Well
+
+- **Template Method pattern**: The `BaseBarcode` pipeline is a sound design. Adding a new barcode format means subclassing and implementing a known set of methods.
+- **XML-driven encoding tables**: Separating bar/space patterns from code makes the tables easy to audit against the relevant ISO standards without touching C++.
+- **`Symbol` abstraction**: A clean, format-agnostic representation that would survive a rendering-layer swap.
+- **EAN/UPC family hierarchy**: Grouping these four formats under `BaseEANUPC` with shared checksum and guard-pattern logic is correct and avoids duplication.
+- **RapidXML choice**: Lightweight, header-only, and appropriate for static config files read at startup.


### PR DESCRIPTION
## Summary

This PR fixes five critical bugs that cause incorrect barcode output, out-of-bounds access, and undefined behavior:

### Bugs Fixed

1. **Symbol::arrayIntoVector()** — `vector::assign()` was overwriting the entire vector on each iteration instead of assigning individual elements. Changed to direct indexing `destination[iter] = holdingVar`.

2. **Code128::verifyContent()** — Impossible condition `(testChar < 0 && testChar > 127)` always evaluated to false. Changed to `||` to properly reject out-of-range characters.

3. **Interleaved2of5::encodeSymbol()** — Loop accessed `data->at(ii + 1)` unsafely and had double increments causing pairs to be skipped. Fixed loop to iterate by 2 with proper bounds check.

4. **BaseEANUPC::encodeCheckCharacter()** — Initialized `count` with `NULL` (wrong type) and left it uninitialized in default case, causing undefined behavior. Changed to `int count = 0` and added initialization in default branch.

5. **Interleaved2of5::encodeCheckCharacter()** — Double-decremented loop counters (`cc--` in for-head and loop body), skipping digits and producing wrong checksums. Fixed loop logic to properly iterate through odd and even positions.

### Additional Changes

- Removed duplicate manual increment `ii++` from Interleaved2of5 loop
- Removed debug output `cout << completedDataString << endl`
- Minor whitespace cleanup for consistency
- Added comprehensive REVIEW.md documenting all issues found in code review

### Impact

These fixes are essential for correct barcode generation. The Symbol bug corrupts **every** encoded symbol. The Interleaved2of5 bugs cause out-of-bounds access and wrong check digits. The Code128 validation bug allows invalid input.