### PR TITLE
Fix memory leaks, remove debug output, clean up style across all files

### DIFF
--- a/BarcodeKit/Base128.cpp
+++ b/BarcodeKit/Base128.cpp
@@ -25,7 +25,7 @@
 using namespace std;
 using namespace rapidxml;
 
-#pragma mark --Con/Destructors--
+// MARK: -- Con/Destructors --
 
 Base128::Base128( )
 {
@@ -39,7 +39,7 @@ Base128::~Base128( )
 }
 
 
-#pragma mark --Methods--
+// MARK: -- Methods --
 
 void Base128::encodeSymbol ( const string *data )
 {

--- a/BarcodeKit/Base128.h
+++ b/BarcodeKit/Base128.h
@@ -16,18 +16,15 @@
 #include <string> 
 #include "rapidxml.hpp"
 
-using namespace std;
-using namespace rapidxml;
-
 class Base128 : public BaseBarcode
 {
 	protected:
 	Base128( );
 	~Base128( );
-	virtual void encodeSymbol ( const string *data );
+	virtual void encodeSymbol ( const std::string *data );
 	virtual int returnCheckCharASCII(  ) = 0;
-	
-	vector< int >* checkCharList;
+
+	std::vector< int >* checkCharList;
 };
 
 #endif

--- a/BarcodeKit/BaseBarcode.cpp
+++ b/BarcodeKit/BaseBarcode.cpp
@@ -16,7 +16,9 @@
 #include <sstream>
 #include "rapidxml.hpp"
 
-#pragma mark --Con/Destructors--
+using namespace std;
+
+// MARK: -- Con/Destructors --
 
 BaseBarcode::BaseBarcode( )
 {
@@ -28,9 +30,9 @@ BaseBarcode::~BaseBarcode( )
 	//empty
 }
 
-#pragma mark --Accessor Methods--
+// MARK: -- Accessor Methods --
 
-#pragma mark --Getters--
+// MARK: -- Getters --
 
 vector<int> BaseBarcode::getQuietzoneWidths( )
 {
@@ -44,9 +46,9 @@ deque<Symbol*> BaseBarcode::getEncodedSymbols( )
 }
 
 
-int BaseBarcode::getCheckcharModulus( )
+int BaseBarcode::getCheckCharModulus( )
 {
-	return checkcharModulus;
+	return checkCharModulus;
 }
 
 
@@ -56,7 +58,7 @@ int BaseBarcode::getDataLength( )
 }
 
 
-#pragma mark --Setters--
+// MARK: -- Setters --
 
 void BaseBarcode::setQuietzoneWidths( int left, int right, int upper, int lower )
 {
@@ -65,7 +67,7 @@ void BaseBarcode::setQuietzoneWidths( int left, int right, int upper, int lower 
 	quietzoneWidths.push_back( right );
 	quietzoneWidths.push_back( upper );
 	quietzoneWidths.push_back( lower );
-							  
+
 }
 
 
@@ -77,20 +79,20 @@ void BaseBarcode::addEncodedSymbol( Symbol* symbol )
 
 void BaseBarcode::addEncodedSymbol( Symbol* symbol, int position )
 {
-	if ( position == 0 ) 
+	if ( position == 0 )
 	{
 		this->encodedSymbols.insert( this->encodedSymbols.begin( ), symbol );
-	} 
-	else 
+	}
+	else
 	{
 		this->encodedSymbols.insert( this->encodedSymbols.begin( ) + position, symbol );
-	} 
+	}
 }
 
 
-void BaseBarcode::setCheckcharModulus( int modulus )
+void BaseBarcode::setCheckCharModulus( int modulus )
 {
-	this->checkcharModulus = modulus;
+	this->checkCharModulus = modulus;
 }
 
 
@@ -100,11 +102,11 @@ void BaseBarcode::setDataLength( int length )
 }
 
 
-#pragma mark --Private internal methods--
+// MARK: -- Private internal methods --
 
 bool BaseBarcode::verifyData ( const string *data )
 {
-	if ( this->verifyLength( data->length( ) ) && this->verifyContent( data ) ) 
+	if ( this->verifyLength( data->length( ) ) && this->verifyContent( data ) )
 	{
 		return true;
 	}
@@ -115,19 +117,19 @@ bool BaseBarcode::verifyData ( const string *data )
 
 bool BaseBarcode::verifyLength ( const int length )
 {
-	if ( this->dataLength == -1 ) 
+	if ( this->dataLength == -1 )
 	{
 		return true; //if there is no length limit
 	}
-	if ( this->dataLength == length ) 
+	if ( this->dataLength == length )
 	{
-		return true; //if the requested length meets the comaprison
+		return true; //if the requested length meets the comparison
 	}
 	cerr << "Data string length does not pass verification" << endl; //else throw error
 	return false;
 }
 
-#pragma mark --Helper Methods--
+// MARK: -- Helper Methods --
 
 Symbol* BaseBarcode::createSymbol( int st, int ic, int le, int fp, vector<int> *aVector ) //make a new symbol with passed values
 {
@@ -146,52 +148,49 @@ char* BaseBarcode::getXMLToParse( string *fileTitle ) //Safely get the XML file 
 	char *ft = new char[ fileTitle->length( ) + 1 ];
 	strcpy( ft, fileTitle->c_str( ) );
 	ifstream xmlfile ( ft, ios::in );
-	
+	delete[] ft;	// free the temporary filename buffer
+
 	vector<string> xmlcontent;
 	string xmlentry;
 	string xmltoparse;
-	
-	if ( xmlfile.is_open( ) )							//open the file
+
+	if ( xmlfile.is_open( ) )						//open the file
 	{
-		while ( getline( xmlfile, xmlentry ) )			//get the data
+		while ( getline( xmlfile, xmlentry ) )		//get the data
 		{
 			xmlcontent.push_back( xmlentry + "\n" );	//add data to vector
 		}
 		xmlfile.close( );
-		
+
 		for ( int i = 0; i < xmlcontent.size( ); i++ )	//iterate through vector into string
 		{
 			xmltoparse += xmlcontent[ i ];
 		}
 	}
-	
-	char * cxml = new char [ xmltoparse.size( ) + 1 ];	//copy string into cstring
-	strcpy ( cxml, xmltoparse.c_str( ) );
-	
+
+	char *cxml = new char[ xmltoparse.size( ) + 1 ];	//copy string into cstring
+	strcpy( cxml, xmltoparse.c_str( ) );
+
 	return cxml;
 }
 
 
 vector<string> BaseBarcode::returnDOMValues( rapidxml::xml_node< > *node ) //Return contents of a single named or unnamed node in the DOM
 {
-	vector<string> *returnValues = new vector<string>;
-	//cout << node->name( ) << ":";
+	vector<string> returnValues;	// local variable — no heap allocation needed
 	rapidxml::xml_node< > *datanode = node->first_node( );
-	while ( datanode != 0 ) 
+	while ( datanode != 0 )
 	{
-		//cout << " - " << datanode->name( );
 		rapidxml::xml_node< > *childnode = datanode->first_node( );
-		while ( childnode != 0 ) 
+		while ( childnode != 0 )
 		{
-			//cout << childnode->name( ) << " is " << childnode->value( );
 			string aValue = childnode->value( );
-			returnValues->push_back( aValue );
+			returnValues.push_back( aValue );
 			childnode = childnode->next_sibling( );
 		}
 		datanode = datanode->next_sibling( );
 	}
-	//cout << endl;
 	node = node->next_sibling( );
-	
-	return *returnValues;
+
+	return returnValues;
 }

--- a/BarcodeKit/BaseBarcode.h
+++ b/BarcodeKit/BaseBarcode.h
@@ -1,7 +1,7 @@
 //
 //  BaseBarcode.h
 //  BarcodeKit
-//	Abstract Base Class for Barcode class heirarchy
+//	Abstract Base Class for Barcode class hierarchy
 //  Created by Robert Stearn on 22.04.12.
 //  Copyright (c) 2012 Cocoadelica. All rights reserved.
 //
@@ -15,49 +15,47 @@
 #include <deque>
 #include "rapidxml.hpp"
 
-using namespace std;
-
 class BaseBarcode
 {
 	public:
 	//Accessors
-	vector< int > getQuietzoneWidths( );
-	deque< Symbol* > getEncodedSymbols( );
-	int getCheckcharModulus( );
+	std::vector< int > getQuietzoneWidths( );
+	std::deque< Symbol* > getEncodedSymbols( );
+	int getCheckCharModulus( );
 	int getDataLength( );
-	
+
 	protected:
 	//Build and Destroy
 	BaseBarcode( );
-	~BaseBarcode( ); 
-	
-	//Accessors	
+	~BaseBarcode( );
+
+	//Accessors
 	void setQuietzoneWidths( int left, int right, int upper, int lower );
 	void addEncodedSymbol( Symbol* symbol );
 	void addEncodedSymbol( Symbol* symbol, int position );
-	void setCheckcharModulus( int modulus );
+	void setCheckCharModulus( int modulus );
 	void setDataLength( int length );
-					 
+
 	//Methods
-	virtual bool verifyData ( const string *data );
+	virtual bool verifyData ( const std::string *data );
 	virtual bool verifyLength ( const int length );
-	virtual bool verifyContent ( const string *content ) = 0;
-	
-	virtual void encodeSymbol ( const string *data ) = 0;
+	virtual bool verifyContent ( const std::string *content ) = 0;
+
+	virtual void encodeSymbol ( const std::string *data ) = 0;
 	virtual void encodeStartStop ( ) = 0;
 	virtual void encodeQuietZones ( ) = 0;
-	virtual void encodeCheckCharacter ( const string *data ) = 0;
-	
-	Symbol* createSymbol( int st, int ic, int le, int fp, vector< int > *aVector );
-	char* getXMLToParse( string *fileTitle );
-	vector<string> returnDOMValues( rapidxml::xml_node< > *node );
+	virtual void encodeCheckCharacter ( const std::string *data ) = 0;
+
+	Symbol* createSymbol( int st, int ic, int le, int fp, std::vector< int > *aVector );
+	char* getXMLToParse( std::string *fileTitle );
+	std::vector<std::string> returnDOMValues( rapidxml::xml_node< > *node );
 
 	//iVars
-	vector< int > quietzoneWidths;
-	deque< Symbol* > encodedSymbols;
-	int checkcharModulus;
-	int dataLength;	
-	string completedDataString;
+	std::vector< int > quietzoneWidths;
+	std::deque< Symbol* > encodedSymbols;
+	int checkCharModulus;
+	int dataLength;
+	std::string completedDataString;
 };
-					 
+
 #endif

--- a/BarcodeKit/BaseEANUPC.cpp
+++ b/BarcodeKit/BaseEANUPC.cpp
@@ -21,7 +21,7 @@
 
 BaseEANUPC::BaseEANUPC ( )
 {
-	BaseBarcode::setCheckcharModulus( 10 );
+	BaseBarcode::setCheckCharModulus( 10 );
 }
 
 BaseEANUPC::~BaseEANUPC ( )
@@ -47,7 +47,6 @@ bool BaseEANUPC::verifyContent ( const string *content )
 			return false;
 		}
 	}
-	cout << "Passed content check" << endl;
 	return true;
 }
 
@@ -109,7 +108,6 @@ void BaseEANUPC::encodeCheckCharacter ( const string *data )
 	output4.flush( );
 	newString->append( output4.str( ) );
 	completedDataString = *newString;
-	cout << "Amended string: " << completedDataString << endl;
 	encodeSymbol( newString );
 }
 

--- a/BarcodeKit/BaseEANUPC.h
+++ b/BarcodeKit/BaseEANUPC.h
@@ -17,20 +17,18 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-
 class BaseEANUPC : public BaseBarcode, public IGuardPatterns
 {
 	public:
 	BaseEANUPC( );
 	~BaseEANUPC( );
-	bool verifyContent ( const string *content );
-	virtual void encodeSymbol ( const string *data );
+	bool verifyContent ( const std::string *content );
+	virtual void encodeSymbol ( const std::string *data );
 	virtual void encodeQuietZones ( );
 	virtual void encodeStartStop( );
-	virtual void encodeCheckCharacter ( const string *data );
-	virtual void setGuardPatterns( string left, string centre, string right ) = 0;
-	virtual vector< string > getGuardPatterns( ) = 0;
+	virtual void encodeCheckCharacter ( const std::string *data );
+	virtual void setGuardPatterns( std::string left, std::string centre, std::string right ) = 0;
+	virtual std::vector< std::string > getGuardPatterns( ) = 0;
 	virtual void encodeGuardPatterns( ) = 0;
 };
 

--- a/BarcodeKit/Codabar.h
+++ b/BarcodeKit/Codabar.h
@@ -16,25 +16,22 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class Codabar : public BaseBarcode
 {
 	public:
 	Codabar( );
-	Codabar( string *data );
+	Codabar( std::string *data );
 	~Codabar( );
-	bool verifyContent ( const string *content );
-	void encodeSymbol ( const string *data );
+	bool verifyContent ( const std::string *content );
+	void encodeSymbol ( const std::string *data );
 	void encodeStartStop ( );
 	void encodeQuietZones ( );
-	void encodeCheckCharacter ( const string *data );
-	
+	void encodeCheckCharacter ( const std::string *data );
+
 	private:
-	string filename;
-	xml_document< > parsed_xml;
-	vector< int >* stringToVector( string aString );
+	std::string filename;
+	rapidxml::xml_document< > parsed_xml;
+	std::vector< int >* stringToVector( std::string aString );
 };
 
 #endif

--- a/BarcodeKit/Code128.cpp
+++ b/BarcodeKit/Code128.cpp
@@ -30,7 +30,7 @@ using namespace rapidxml;
 Code128::Code128( string *data )
 {
 	checkCharList = new vector< int >;
-	BaseBarcode::setCheckcharModulus( kModulus );
+	BaseBarcode::setCheckCharModulus( kModulus );
 	filename = "Base128.xml";
 	parsed_xml.parse< 0 >( getXMLToParse( &filename ) );
 	setDataLength( -1 ); //variable length symbol
@@ -82,8 +82,8 @@ Code128::Code128( string *data )
 
 Code128::~Code128( )
 {
-	checkCharList = NULL;
 	delete checkCharList;
+	checkCharList = NULL;
 }
 
 

--- a/BarcodeKit/Code128.h
+++ b/BarcodeKit/Code128.h
@@ -16,26 +16,23 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class Code128 : public Base128
 {
 	public:
-	Code128( string *data );
+	Code128( std::string *data );
 	~Code128( );
 	int getSet( char first );
-	bool verifyContent ( const string *content );
+	bool verifyContent ( const std::string *content );
 	void encodeStartStop ( );
 	void encodeQuietZones ( );
-	void encodeCheckCharacter ( const string *data );
+	void encodeCheckCharacter ( const std::string *data );
 	int returnCheckCharASCII(  );
-	
+
 	private:
-	string filename;
-	xml_document< > parsed_xml;
-	vector< int >* stringToVector( string aString );
-	
+	std::string filename;
+	rapidxml::xml_document< > parsed_xml;
+	std::vector< int >* stringToVector( std::string aString );
+
 };
 
 #endif

--- a/BarcodeKit/Code39.cpp
+++ b/BarcodeKit/Code39.cpp
@@ -27,7 +27,7 @@ using namespace rapidxml;
 
 Code39::Code39( string *data )
 {
-	BaseBarcode::setCheckcharModulus( kModulus );
+	BaseBarcode::setCheckCharModulus( kModulus );
 	filename = "Basic.xml";
 	parsed_xml.parse< 0 >( getXMLToParse( &filename ) );
 	setDataLength( -1 ); //variable length symbol
@@ -130,9 +130,10 @@ void Code39::encodeStartStop ( )
 	
 	vector< int > *pattern = stringToVector( returnedData );
 	
-	Symbol *startstopSymbol = createSymbol( 4, 1, 1, 0, pattern );
-	BaseBarcode::addEncodedSymbol( startstopSymbol, 0 );
-	BaseBarcode::addEncodedSymbol( startstopSymbol, BaseBarcode::encodedSymbols.size( ) );
+	Symbol *startSymbol = createSymbol( 4, 1, 1, 0, pattern );
+	BaseBarcode::addEncodedSymbol( startSymbol, 0 );
+	Symbol *stopSymbol = createSymbol( 4, 1, 1, 0, pattern );
+	BaseBarcode::addEncodedSymbol( stopSymbol, BaseBarcode::encodedSymbols.size( ) );
 }
 
 
@@ -162,7 +163,7 @@ void Code39::encodeCheckCharacter ( const string *data )
 		accumulator = accumulator + returnedINT;
 	}
 	
-	int modulo = accumulator % BaseBarcode::getCheckcharModulus( );
+	int modulo = accumulator % BaseBarcode::getCheckCharModulus( );
 	char returnChar = checksumCharForInt( modulo );
 	
 	xml_node< > *node = NULL;

--- a/BarcodeKit/Code39.h
+++ b/BarcodeKit/Code39.h
@@ -16,24 +16,21 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class Code39 : public BaseBarcode
 {
 	public:
-	Code39( string *data );
+	Code39( std::string *data );
 	~Code39( );
-	bool verifyContent ( const string *content );
-	void encodeSymbol ( const string *data );
+	bool verifyContent ( const std::string *content );
+	void encodeSymbol ( const std::string *data );
 	void encodeStartStop ( );
 	void encodeQuietZones ( );
-	void encodeCheckCharacter ( const string *data );
-	
+	void encodeCheckCharacter ( const std::string *data );
+
 	private:
-	string filename;
-	xml_document< > parsed_xml;
-	vector< int >* stringToVector( string aString );
+	std::string filename;
+	rapidxml::xml_document< > parsed_xml;
+	std::vector< int >* stringToVector( std::string aString );
 	int checksumIntForChar( int aChar );
 	char checksumCharForInt( int anInt );
 };

--- a/BarcodeKit/EAN13.h
+++ b/BarcodeKit/EAN13.h
@@ -17,26 +17,23 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class EAN13 : public BaseEANUPC, public IGuardPatterns
 {
 public:
-	EAN13( string *data );
+	EAN13( std::string *data );
 	~EAN13( );
-	void encodeSymbol( const string *data );
+	void encodeSymbol( const std::string *data );
 	void encodeQuietZones( );
 	void encodeGuardPatterns( );
-	void setGuardPatterns( string left, string centre, string right );
-	vector< string > getGuardPatterns( );
-	vector< int >* stringToVector( string aString );
-	
-	string filename;
-	string parityFilename;
-	vector< string >guardPatterns;
-	xml_document< > parsed_xml;
-	xml_document< > parity_xml;
+	void setGuardPatterns( std::string left, std::string centre, std::string right );
+	std::vector< std::string > getGuardPatterns( );
+	std::vector< int >* stringToVector( std::string aString );
+
+	std::string filename;
+	std::string parityFilename;
+	std::vector< std::string > guardPatterns;
+	rapidxml::xml_document< > parsed_xml;
+	rapidxml::xml_document< > parity_xml;
 };
 
 #endif

--- a/BarcodeKit/EAN8.h
+++ b/BarcodeKit/EAN8.h
@@ -17,25 +17,22 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class EAN8 : public BaseEANUPC, public IGuardPatterns
 {
 public:
-	EAN8( string *data );
+	EAN8( std::string *data );
 	~EAN8( );
-	void encodeSymbol( const string *data );
+	void encodeSymbol( const std::string *data );
 	void encodeQuietZones( );
 	void encodeGuardPatterns( );
-	void setGuardPatterns( string left, string centre, string right );
-	vector< string > getGuardPatterns( );
-	vector< int >* stringToVector( string aString );
-	
-	string filename;
-	string parityFilename;
-	vector< string >guardPatterns;
-	xml_document< > parsed_xml;
+	void setGuardPatterns( std::string left, std::string centre, std::string right );
+	std::vector< std::string > getGuardPatterns( );
+	std::vector< int >* stringToVector( std::string aString );
+
+	std::string filename;
+	std::string parityFilename;
+	std::vector< std::string > guardPatterns;
+	rapidxml::xml_document< > parsed_xml;
 };
 
 #endif

--- a/BarcodeKit/IGuardPatterns.h
+++ b/BarcodeKit/IGuardPatterns.h
@@ -12,13 +12,11 @@
 #include <vector> 
 #include <string>
 
-using namespace std;
-
 class IGuardPatterns
 {
 	public:
-	virtual void setGuardPatterns( string left, string centre, string right ) = 0;
-	virtual vector< string > getGuardPatterns( ) = 0;
+	virtual void setGuardPatterns( std::string left, std::string centre, std::string right ) = 0;
+	virtual std::vector< std::string > getGuardPatterns( ) = 0;
 	virtual void encodeGuardPatterns( ) = 0;
 };
 

--- a/BarcodeKit/Interleaved2of5.cpp
+++ b/BarcodeKit/Interleaved2of5.cpp
@@ -25,7 +25,7 @@ using namespace rapidxml;
 
 Interleaved2of5::Interleaved2of5( string *data )
 {
-	BaseBarcode::setCheckcharModulus( kModulus );
+	BaseBarcode::setCheckCharModulus( kModulus );
 	filename = "Basic.xml";
 	parsed_xml.parse< 0 >( getXMLToParse( &filename ) );
 	setDataLength( -1 ); //variable length symbol

--- a/BarcodeKit/Interleaved2of5.h
+++ b/BarcodeKit/Interleaved2of5.h
@@ -16,25 +16,21 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class Interleaved2of5 : public BaseBarcode
 {
 	public:
-	Interleaved2of5( string *data );
+	Interleaved2of5( std::string *data );
 	~Interleaved2of5( );
-	bool verifyContent ( const string *content );
-	void encodeCheckCharacter ( const string *data );
-	void encodeSymbol ( const string *data );
+	bool verifyContent ( const std::string *content );
+	void encodeCheckCharacter ( const std::string *data );
+	void encodeSymbol ( const std::string *data );
 	void encodeStartStop ( );
 	void encodeQuietZones ( );
-	
-	
+
 	private:
-	string filename;
-	xml_document< > parsed_xml;
-	vector< int >* stringToVector( string aString );
+	std::string filename;
+	rapidxml::xml_document< > parsed_xml;
+	std::vector< int >* stringToVector( std::string aString );
 };
 
 #endif

--- a/BarcodeKit/Symbol.cpp
+++ b/BarcodeKit/Symbol.cpp
@@ -1,6 +1,6 @@
 //
 //  Symbol.cpp
-//	Object represents a single character, data or non-data, storing it's attributes and encoding
+//	Object represents a single character, data or non-data, storing its attributes and encoding
 //  BarcodeKit
 //
 //  Created by Robert Stearn on 13.04.12.
@@ -13,11 +13,11 @@
 
 using namespace std;
 
-#pragma mark --Constructor methods--
+// MARK: -- Constructor methods --
 
 Symbol::Symbol( )
 {
-	
+
 }
 
 Symbol::Symbol( int characterData[ ], int dataLength )
@@ -48,37 +48,34 @@ Symbol::Symbol( int characterData[ ], int dataLength, int startWith, int gapWidt
 
 Symbol::~Symbol( )
 {
-	
 }
 
 
-#pragma mark --Accessor methods--
+// MARK: -- Accessor methods --
 
 int Symbol::getLeadingElement( )
 {
-	return Symbol::leadingElement;
+	return leadingElement;
 }
 
 int Symbol::getIntercharGap( )
 {
-	return Symbol::intercharacterGap;
+	return intercharacterGap;
 }
 
 int Symbol::getSymbolType( )
 {
-	return Symbol::symbolType;
+	return symbolType;
 }
 
 vector<int>* Symbol::getEncodedData( )
 {
-	vector<int> *tempVector = new vector<int>;
-	tempVector->insert( tempVector->begin( ), Symbol::encodedSymbol.begin( ), Symbol::encodedSymbol.end( ) );
-	return tempVector;
+	return &encodedSymbol;	// non-owning pointer — caller must not delete
 }
 
-int Symbol::getForcePostion( )
+int Symbol::getForcePosition( )
 {
-	return Symbol::forcePosition;
+	return forcePosition;
 }
 
 int Symbol::getAsciiEquivalent( )
@@ -88,46 +85,46 @@ int Symbol::getAsciiEquivalent( )
 
 string Symbol::getTextEquivalent( )
 {
-	return  textEquivalent;
+	return textEquivalent;
 }
 
 void Symbol::setLeadingElement( int le )
 {
-	Symbol::leadingElement = le;
+	leadingElement = le;
 }
 
 void Symbol::setIntercharGap( int icg )
 {
-	Symbol::intercharacterGap = icg;
+	intercharacterGap = icg;
 }
 
 void Symbol::setSymbolType( int st )
 {
-	Symbol::symbolType = st;
+	symbolType = st;
 }
 
 void Symbol::setEncodedData( vector<int> const& ec )
 {
-    Symbol::encodedSymbol = ec;
+	encodedSymbol = ec;
 }
 
 void Symbol::setForcedPosition( int fp )
 {
-	Symbol::forcePosition = fp;
+	forcePosition = fp;
 }
 
 void Symbol::setAsciiEquivalent( int ae )
 {
-	Symbol::asciiEquivalent = ae;
+	asciiEquivalent = ae;
 }
 
 void Symbol::setTextEquivalent( string &te )
 {
-	Symbol::textEquivalent = te;
+	textEquivalent = te;
 }
 
 
-#pragma mark --Private internal methods--
+// MARK: -- Private internal methods --
 
 void Symbol::arrayIntoVector( int source[ ], int sourceLength, vector<int> &destination )
 {

--- a/BarcodeKit/Symbol.h
+++ b/BarcodeKit/Symbol.h
@@ -1,6 +1,6 @@
 //
 //  Symbol.h
-//	Object represents a single character, data or non-data, storing it's attributes and encoding
+//	Object represents a single character, data or non-data, storing its attributes and encoding
 //  BarcodeKit
 //
 //  Created by Robert Stearn on 13.04.12.
@@ -13,8 +13,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 class Symbol
 {
 	public:
@@ -26,35 +24,35 @@ class Symbol
 	Symbol( int characterData[ ], int dataLength, int startWith, int gapWidth, int ofType );	//...or with everything supplied
 	//TODO add constructors for new ivars
 	~Symbol( );
-	
+
 	//Accessors
 	int getLeadingElement( );
 	int getIntercharGap( );
 	int getSymbolType( );
-	vector<int>* getEncodedData( );
-	int getForcePostion( );
+	std::vector<int>* getEncodedData( );
+	int getForcePosition( );
 	int getAsciiEquivalent( );
-	string getTextEquivalent( );
-	
+	std::string getTextEquivalent( );
+
 	void setLeadingElement( int le );
 	void setIntercharGap( int icg );
 	void setSymbolType( int st );
-	void setEncodedData( vector<int> const& ec );
+	void setEncodedData( std::vector<int> const& ec );
 	void setForcedPosition( int fp );
 	void setAsciiEquivalent( int ae );
-	void setTextEquivalent( string &te );
-	
+	void setTextEquivalent( std::string &te );
+
 	private:
 	//ivars
 	int leadingElement;																			//0 for space, 1 for bar
 	int intercharacterGap;																		//0..n as multiple of X width
 	int symbolType;																				//0,1..4 indicates data or specific non-data type
-	vector<int>encodedSymbol;																	//vector of element widths as multiples of X width
+	std::vector<int> encodedSymbol;																//vector of element widths as multiples of X width
 	int forcePosition;																			//int value to specify ultimate position in destination array
 	int asciiEquivalent;
-	string textEquivalent;
-	
-	void arrayIntoVector( int source[ ], int sourceLength, vector<int> &destination );			//since we do this in all the constructors, spin it out
+	std::string textEquivalent;
+
+	void arrayIntoVector( int source[ ], int sourceLength, std::vector<int> &destination );	//since we do this in all the constructors, spin it out
 };
 
 #endif

--- a/BarcodeKit/UPCA.h
+++ b/BarcodeKit/UPCA.h
@@ -17,25 +17,22 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class UPCA : public BaseEANUPC, public IGuardPatterns
 {
 public:
-	UPCA( string *data );
+	UPCA( std::string *data );
 	~UPCA( );
-	void encodeSymbol( const string *data );
+	void encodeSymbol( const std::string *data );
 	void encodeQuietZones( );
 	void encodeGuardPatterns( );
-	void setGuardPatterns( string left, string centre, string right );
-	vector< string > getGuardPatterns( );
-	vector< int >* stringToVector( string aString );
-	
-	string filename;
-	string parityFilename;
-	vector< string >guardPatterns;
-	xml_document< > parsed_xml;
+	void setGuardPatterns( std::string left, std::string centre, std::string right );
+	std::vector< std::string > getGuardPatterns( );
+	std::vector< int >* stringToVector( std::string aString );
+
+	std::string filename;
+	std::string parityFilename;
+	std::vector< std::string > guardPatterns;
+	rapidxml::xml_document< > parsed_xml;
 };
 
 #endif

--- a/BarcodeKit/UPCE.cpp
+++ b/BarcodeKit/UPCE.cpp
@@ -67,7 +67,6 @@ bool UPCE::verifyContent ( const string *content )
 	//leading zero
 	if ( content->at( 0 ) != '0' ) 
 	{
-		cout << "failed on leading zero" << endl;
 		return false;
 	}
 	//characters in range

--- a/BarcodeKit/UPCE.h
+++ b/BarcodeKit/UPCE.h
@@ -17,35 +17,32 @@
 #include <deque> 
 #include <string> 
 
-using namespace std;
-using namespace rapidxml;
-
 class UPCE : public BaseEANUPC, public IGuardPatterns
 {
 public:
-	//**consructors**
-	UPCE( string *data );
+	//**constructors**
+	UPCE( std::string *data );
 	~UPCE( );
-	void encodeSymbol( const string *data );
+	void encodeSymbol( const std::string *data );
 	void encodeQuietZones( );
 	void encodeGuardPatterns( );
-	void setGuardPatterns( string left, string centre, string right );
-	//void encodeCheckCharacter( const string *data );
-	vector< string > getGuardPatterns( );
-	vector< int >* stringToVector( string aString );
-	bool verifyContent ( const string *content );
-	
+	void setGuardPatterns( std::string left, std::string centre, std::string right );
+	//void encodeCheckCharacter( const std::string *data );
+	std::vector< std::string > getGuardPatterns( );
+	std::vector< int >* stringToVector( std::string aString );
+	bool verifyContent ( const std::string *content );
+
 	//**format specific methods**
-	string* zeroSuppression( const string *data );
-	bool isZeroSuppresible( const string *data );
+	std::string* zeroSuppression( const std::string *data );
+	bool isZeroSuppresible( const std::string *data );
 	int getZSPattern( );
 	void setZSPattern( int pattern );
-	
-	string filename;
-	string checkFilename;
-	vector< string >guardPatterns;
-	xml_document< > parsed_xml;
-	xml_document< > parity_xml;
+
+	std::string filename;
+	std::string checkFilename;
+	std::vector< std::string > guardPatterns;
+	rapidxml::xml_document< > parsed_xml;
+	rapidxml::xml_document< > parity_xml;
 	int zsPattern;
 };
 

--- a/BarcodeKit/main.cpp
+++ b/BarcodeKit/main.cpp
@@ -72,7 +72,7 @@ void testSymbol( Symbol *testSymbol ) //Output the values of a Symbol object to 
 	cout << "Symbol Type: " << testSymbol->getSymbolType( ) << endl;
 	cout << "Leading Element: " << testSymbol->getLeadingElement( ) << endl;
 	cout << "IC Gap: " << testSymbol->getIntercharGap( ) << endl;
-	cout << "Force Position: " << testSymbol->getForcePostion( ) << endl;
+	cout << "Force Position: " << testSymbol->getForcePosition( ) << endl;
 	cout << "Data: ";
 	for ( int ii = 0; ii < testSymbol->getEncodedData( )->size( ); ii++ ) 
 	{


### PR DESCRIPTION
Memory management
- BaseBarcode::getXMLToParse(): delete[] ft immediately after the ifstream is opened; the buffer was allocated for the filename conversion but never freed
- BaseBarcode::returnDOMValues(): replaced heap-allocated vector<string>* with a local variable; the old code allocated on the heap, returned by value (copy), and leaked the original allocation on every call
- Symbol::getEncodedData(): removed per-call heap allocation; now returns a non-owning pointer to the internal encodedSymbol member directly — callers must not delete the result
- Code128::~Code128(): moved delete before the NULL assignment so checkCharList is actually freed; previously the pointer was nulled first, making delete a no-op
- Code39::encodeStartStop(): created separate startSymbol and stopSymbol objects instead of inserting the same pointer twice into the deque, eliminating a potential double-free on cleanup

Debug output removed
- BaseEANUPC::verifyContent(): removed "Passed content check" cout
- BaseEANUPC::encodeCheckCharacter(): removed "Amended string: ..." cout
- UPCE::verifyContent(): removed "failed on leading zero" cout

Typo fixes
- Renamed getCheckcharModulus/setCheckcharModulus → getCheckCharModulus/ setCheckCharModulus in BaseBarcode.h/.cpp and updated all call sites in Code39.cpp, Code128.cpp, BaseEANUPC.cpp, and Interleaved2of5.cpp
- Renamed getForcePostion → getForcePosition in Symbol.h, Symbol.cpp, main.cpp

Style: scope resolution
- Removed redundant Symbol:: prefix from all member accesses inside Symbol.cpp accessor methods (e.g. Symbol::leadingElement → leadingElement)

Style: using namespace in headers
- Removed using namespace std and using namespace rapidxml from all 13 headers (BaseBarcode.h, Symbol.h, IGuardPatterns.h, BaseEANUPC.h, Base128.h, Code39.h, Code128.h, EAN13.h, EAN8.h, UPCA.h, UPCE.h, Codabar.h, Interleaved2of5.h)
- Qualified all affected types with std:: or rapidxml:: in each header's declarations so every consumer gets explicit namespace resolution

Style: #pragma mark
- Replaced Objective-C-specific #pragma mark directives with standard // MARK: comments in BaseBarcode.cpp, Symbol.cpp, and Base128.cpp